### PR TITLE
Enable caching of processed assets

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -39,7 +39,7 @@ export function processSource(
   file: string,
   original: SourceAndMapResult,
   sideEffectFree: SideEffectFree
-): SourceAndMapResult {
+): string {
   const src = original.source
     .split(webpackModuleHeader)
     .map((v) => {
@@ -77,5 +77,5 @@ export function processSource(
     })
     .join(webpackModuleHeader);
 
-  return { source: src, map: original.map };
+  return src;
 }


### PR DESCRIPTION
Add new `cache` option and automatically turn it on when `webpack` is in watch mode