### PR TITLE
return match of requireVariables map directly

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -21,7 +21,7 @@ function collectRequires(src: string, sideEffectFree: SideEffectFree) {
     // if referencing another require var, inline it
     requireExpression = requireExpression.replace(
       /\w+_WEBPACK_[A-Z]+_MODULE_\w+/,
-      (s) => (requireVariables.get(s) && requireVariables.get(s).requireExpression) || s
+      (s) => requireVariables.get(s) || s
     );
 
     if (!checkSideEffectFree(sideEffectFree, requireExpression)) {

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -11,7 +11,7 @@ function checkSideEffectFree(sideEffectFree: SideEffectFree, requireExpression: 
 
 function collectRequires(src: string, sideEffectFree: SideEffectFree) {
   // Collect require variables
-  const requireVariables = new Map();
+  const requireVariables = new Map<string, string>();
 
   const matches = src.matchAll(importPattern);
   for (const match of matches) {


### PR DESCRIPTION
there is no longer a data type that contains an object but the
map just returns a string